### PR TITLE
Add a target to specifically build tools + fix GenApi execution

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -9,6 +9,8 @@
     <RestoreConfigFile>src\NuGet.config</RestoreConfigFile>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
+    <!-- Flag to control whether or not to build Microsoft.DotNet.GenAPI project in tools -->
+    <BuildTools Condition="'$(BuildTools)' == ''">true</BuildTools>
     <!-- Flag to control if Windows drivers should be built or not -->
     <IsEnabledWindows Condition="'$(IsEnabledWindows)' == '' AND '$(TargetsWindows)' == 'true'">true</IsEnabledWindows>
     <IsEnabledWindows Condition="'$(TargetsUnix)' == 'true'">false</IsEnabledWindows>
@@ -54,8 +56,8 @@
 
   <!-- Top Level Build targets -->
   <Target Name="Restore" DependsOnTargets="RestoreNetCore;RestoreNetFx" />
-  <Target Name="BuildAll" DependsOnTargets="BuildNetFx;BuildNetCore" />
-  <Target Name="BuildAllConfigurations" DependsOnTargets="Restore;BuildNetFx;BuildNetCoreAllOS;GenerateNugetPackage" />
+  <Target Name="BuildAll" DependsOnTargets="BuildTools;BuildNetFx;BuildNetCore" />
+  <Target Name="BuildAllConfigurations" DependsOnTargets="Restore;BuildTools;BuildNetFx;BuildNetCoreAllOS;GenerateNugetPackage" />
   <Target Name="BuildTestsNetCore" DependsOnTargets="RestoreTestsNetCore;BuildAKVNetCore;BuildFunctionalTestsNetCore;BuildManualTestsNetCore" />
   <Target Name="BuildTestsNetFx" DependsOnTargets="RestoreTestsNetFx;BuildAKVNetFx;BuildFunctionalTestsNetFx;BuildManualTestsNetFx;" />
 
@@ -75,6 +77,13 @@
   <Target Name="RestoreTestsNetFx">
     <MSBuild Projects="@(ManualTests)" Targets="restore" Properties="TestTargetOS=$(TestOS)netfx" />
     <MSBuild Projects="@(FunctionalTests)" Targets="restore" Properties="TestTargetOS=$(TestOS)netfx" />
+  </Target>
+
+  <Target Name="BuildTools" Condition="'$(BuildTools)' == 'true'">
+    <PropertyGroup>
+      <DotnetBuildCmd>$(DotNetCmd) dotnet build -c Release"</DotnetBuildCmd>
+    </PropertyGroup>
+    <Exec Command="$(DotnetBuildCmd)" WorkingDirectory="$(GenAPISrcDir)Microsoft.DotNet.GenAPI\" />
   </Target>
 
   <Target Name="BuildNetFx" DependsOnTargets="RestoreNetFx" Condition="'$(IsEnabledWindows)' == 'true'">

--- a/tools/targets/NotSupported.targets
+++ b/tools/targets/NotSupported.targets
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <PropertyGroup Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' OR '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
     <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
     <ResolveMatchingContract>true</ResolveMatchingContract>
@@ -9,7 +8,6 @@
     <!-- Not supported sources are created from the ref assembly, we currently don't produce finalizers in dummmy assemblies, so we disable ApiCompat to not fail. -->
     <RunApiCompat>false</RunApiCompat>
     <GenerateDocumentationFile Condition="'$(OSGroup)' != 'Windows_NT'">false</GenerateDocumentationFile>
-    <BuildTools Condition="'$(BuildTools)' == ''">true</BuildTools>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' OR '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
@@ -22,7 +20,6 @@
        Inputs:
          * A contract assembly
          * Reference assemblies
-
        Generates source for the contract that throws PlatformNotSupportedException
   -->
   <Target Name="GenerateNotSupportedSource"
@@ -43,17 +40,12 @@
       <GenAPIArgs>"%(ResolvedMatchingContract.Identity)"</GenAPIArgs>
       <GenAPIArgs>$(GenAPIArgs) -l:"@(_referencePathDirectories)"</GenAPIArgs>
       <GenAPIArgs>$(GenAPIArgs) -o:"$(NotSupportedSourceFile)"</GenAPIArgs>
-      <DotnetBuildCmd>$(DotNetCmd) dotnet build -c Release"</DotnetBuildCmd>
       <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' OR '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">$(GenAPIArgs) -t:"$(GeneratePlatformNotSupportedAssemblyMessage)"</GenAPIArgs>
       <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAssemblyWithGlobalPrefix)' == 'true'">$(GenAPIArgs) -global</GenAPIArgs>
       <GenAPIPath Condition="'$(MSBuildRuntimeType)' == 'core'"> "$(DotNetCmd) $(ToolsArtifactsDir)netcoreapp2.1\Microsoft.DotNet.GenAPI.dll"</GenAPIPath>
       <GenAPIPath Condition="'$(MSBuildRuntimeType)' != 'core'"> "$(ToolsArtifactsDir)net472\Microsoft.DotNet.GenAPI.exe"</GenAPIPath>
     </PropertyGroup>
-    <Message Condition="'$(BuildTools)' != 'true'" Text="Skip building tools." />
-
-    <Exec Command="$(DotnetBuildCmd)" WorkingDirectory="$(GenAPISrcDir)Microsoft.DotNet.GenAPI\" Condition="'$(BuildTools)' == 'true'" />
-    <Exec Command="$(GenAPIPath) $(GenAPIArgs)" WorkingDirectory="$(ToolRuntimePath)" Condition="'$(BuildTools)' == 'true'" />
-
+    <Exec Command="$(GenAPIPath) $(GenAPIArgs)" WorkingDirectory="$(ToolRuntimePath)"/>
     <ItemGroup>
       <FileWrites Include="$(NotSupportedSourceFile)" />
       <Compile Include="$(NotSupportedSourceFile)" />


### PR DESCRIPTION
Steps to build Only tools separately:
```cmd
msbuild /t:BuildTools
msbuild /p:BuildTools=false
```

Or build normally:
```cmd
msbuild
```